### PR TITLE
Now apiKey is an optional parameter for OpenAI builder

### DIFF
--- a/src/main/java/io/github/stefanbratanov/jvm/openai/OpenAIClient.java
+++ b/src/main/java/io/github/stefanbratanov/jvm/openai/OpenAIClient.java
@@ -39,8 +39,11 @@ abstract class OpenAIClient {
   }
 
   HttpRequest.Builder newHttpRequestBuilder(String... headers) {
-    HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().headers(authenticationHeaders);
+    HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder();
+
+    if (authenticationHeaders.length > 0) {
+      httpRequestBuilder.headers(authenticationHeaders);
+    }
     if (headers.length > 0) {
       httpRequestBuilder.headers(headers);
     }


### PR DESCRIPTION
I have slightly changed the behavior of the OpenAI builder, and now apiKey is an optional parameter. 

This may be useful for connecting to the [ollama](https://github.com/ollama/ollama/blob/main/docs/openai.md#curl) server and other openai-compatible APIs - an authentication token may not be required there.

At the same time, I have saved compatibility as before, you can immediately pass the apiKey to the builder